### PR TITLE
Document MacOS setup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@ Simple RUST Game using the [Bevy Engine](https://bevyengine.org/)
 
 ### MacOS Setup
 
+- Ensure [Rust and Cargo are installed](https://www.rust-lang.org/tools/install)
 - Delete the Cargo.lock, as it may otherwise raise an error the first time: `rm Cargo.lock`
 - Install Cmake with [Homebrew](https://brew.sh/): `brew install cmake`
+- Install Cargo Watch: `cargo install cargo-watch`
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 Simple RUST Game using the [Bevy Engine](https://bevyengine.org/)
 
-Fast dev: `cargo watch -q -c -x 'run --features bevy/dynamic'`
+### MacOS Setup
+
+- Delete the Cargo.lock, as it may otherwise raise an error the first time: `rm Cargo.lock`
+- Install Cmake with [Homebrew](https://brew.sh/): `brew install cmake`
+
+### Development
+
+For rapid development: `cargo watch -q -c -x 'run --features bevy/dynamic'`
 
 - YouTube videos for this code base:
     - [Episode 1](https://youtu.be/Yb3vInxzKGE) - Rust Game Development tutorial from Scratch with Bevy Engine


### PR DESCRIPTION
because: Without these steps, otherwise cryptic errors can pop up, which might be a barrier to entry for folks new to Rust.

this commit: Updates the README.md for greater accessibility.

Credit goes to [this post](https://issueexplorer.com/issue/bevyengine/bevy/3057) for detailing the fixes around common issues getting Bevy working on an M1 Mac.